### PR TITLE
Close webrequest when checking certificate

### DIFF
--- a/src/Spookfiles.Testing.Testrunners/Security/CheckCertificateTest.cs
+++ b/src/Spookfiles.Testing.Testrunners/Security/CheckCertificateTest.cs
@@ -90,6 +90,7 @@ namespace Spookfiles.Testing.Testrunners.Security
                     };
                 HttpWebRequest req = SetupWebRequest(o, o.Url + RelativeUrl);
                 var response = (HttpWebResponse) req.GetResponse();
+                response.Close();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This fixed a issue with high response times because of unpredictable
behaviour when the response is not used and not closed. Fixed by Frank
van Moorsel of Primevision, committed on his request by Wim Vandenberghe
of Be-Mobile