### PR TITLE
updated test of fields that should be present in the vehiclestate record...

### DIFF
--- a/src/Spookfiles.Koppelvlak.A/FieldTester.cs
+++ b/src/Spookfiles.Koppelvlak.A/FieldTester.cs
@@ -55,7 +55,7 @@ namespace Spookfiles.Koppelvlak.A
         public static List<string> FieldsThatShouldBePresentInVehicleState()
         {
             var list = new List<string>();
-            list.AddRange(new[] { "measurement_time", "vehicle_id", "vehicle_type", "vehicle_length", "feed_id" });
+            list.AddRange(new[] { "measurement_time", "vehicle_id", "measurements" });
             return list;
         }
     }


### PR DESCRIPTION
...s, since it originally also considered the optional fields as mandatory.